### PR TITLE
Change branding to Tchap

### DIFF
--- a/src/components/structures/MatrixChat.js
+++ b/src/components/structures/MatrixChat.js
@@ -1460,7 +1460,7 @@ export default React.createClass({
     },
 
     _setPageSubtitle: function(subtitle='') {
-        document.title = `Riot ${subtitle}`;
+        document.title = `Tchap ${subtitle}`;
     },
 
     updateStatusIndicator: function(state, prevState) {


### PR DESCRIPTION
Changing app name everywhere. If I don't change this line, after a short time (~2-3 sec) Riot reappear in the browser's title bar.