### PR TITLE
Removing "Low Priority" and "Direct discussion"

### DIFF
--- a/src/components/views/rooms/RoomSettings.js
+++ b/src/components/views/rooms/RoomSettings.js
@@ -770,7 +770,6 @@ module.exports = React.createClass({
 
         const tags = [
             { name: "m.favourite", label: _t('Favourite'), ref: "tag_favourite" },
-            { name: "m.lowpriority", label: _t('Low priority'), ref: "tag_lowpriority" },
         ];
 
         Object.keys(this.state.tags).sort().forEach(function(tagName) {


### PR DESCRIPTION
Removing "Low Priority" and "Direct discussion" in : 
- the left menu on "..." button
- the discussion setting on the gear button on the top bar