### PR TITLE
Fixing a bug where the roomMap is already declared

### DIFF
--- a/src/components/views/rooms/RoomHeader.js
+++ b/src/components/views/rooms/RoomHeader.js
@@ -333,8 +333,8 @@ module.exports = React.createClass({
             );
         }
 
-        const dmRoomMap = new DMRoomMap(MatrixClientPeg.get());
-        let isDMRoom = Boolean(dmRoomMap.getUserIdForRoomId(this.props.room.roomId));
+        const roomMap = new DMRoomMap(MatrixClientPeg.get());
+        let isDMRoom = Boolean(roomMap.getUserIdForRoomId(this.props.room.roomId));
         if (this.props.onSettingsClick && !isDMRoom) {
             settingsButton =
                 <AccessibleButton className="mx_RoomHeader_button" onClick={this.props.onSettingsClick} title={_t("Settings")}>


### PR DESCRIPTION
Fixing a bug where the dmRoomMap constant is considered as already declared because an ES6 import have the same case insensitive name.