### PR TITLE
Change the warning sign by the blue padlock on encrypted messages with unverified devices

### DIFF
--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -764,7 +764,7 @@ function E2ePadlockVerified(props) {
 function E2ePadlockUnverified(props) {
     return (
         <E2ePadlock alt={_t("Encrypted by an unverified device")}
-            src="img/e2e-warning.svg" width="15" height="12"
+            src="img/e2e-verified.svg" width="15" height="12"
             style={{ marginLeft: "-2px" }} {...props} />
     );
 }

--- a/src/components/views/rooms/EventTile.js
+++ b/src/components/views/rooms/EventTile.js
@@ -762,6 +762,8 @@ function E2ePadlockVerified(props) {
 }
 
 function E2ePadlockUnverified(props) {
+    // "Verified" icon is used until another solution is found in order to make
+    // users understand that their messages are encrypted regardless of the icon used.
     return (
         <E2ePadlock alt={_t("Encrypted by an unverified device")}
             src="img/e2e-verified.svg" width="15" height="12"


### PR DESCRIPTION
Resolve #117 