### PR TITLE
Updated some version managing things

### DIFF
--- a/src/components/structures/HomePage.js
+++ b/src/components/structures/HomePage.js
@@ -104,7 +104,7 @@ class HomePage extends React.Component {
             const GeminiScrollbarWrapper = sdk.getComponent("elements.GeminiScrollbarWrapper");
             const TintableSvg = sdk.getComponent("elements.TintableSvg");
             const faqUrl = `${SdkConfig.get()['host_url']}/faq.html`;
-            const version = p.version;
+            const version = p.appVersion;
 
             return (
                 <GeminiScrollbarWrapper autoshow={true} className="tc_HomePage">

--- a/src/components/structures/HomePage.js
+++ b/src/components/structures/HomePage.js
@@ -103,7 +103,7 @@ class HomePage extends React.Component {
         else {
             const GeminiScrollbarWrapper = sdk.getComponent("elements.GeminiScrollbarWrapper");
             const TintableSvg = sdk.getComponent("elements.TintableSvg");
-            const faqUrl = `${SdkConfig.get()['host_url']}/faq.html`;
+            const faqUrl = `${SdkConfig.get()['host_url']}/faq/`;
             const version = p.appVersion;
 
             return (

--- a/src/components/structures/UserSettings.js
+++ b/src/components/structures/UserSettings.js
@@ -41,7 +41,7 @@ import * as FormattingUtils from '../../utils/FormattingUtils';
 
 // if this looks like a release, use the 'version' from package.json; else use
 // the git sha. Prepend version with v, to look like riot-web version
-const REACT_SDK_VERSION = 'dist' in packageJson ? packageJson.version : packageJson.gitHead || '<local>';
+const REACT_SDK_VERSION = packageJson.version || '<local>';
 
 // Simple method to help prettify GH Release Tags and Commit Hashes.
 const semVerRegex = /^v?(\d+\.\d+\.\d+(?:-rc.+)?)(?:-(?:\d+-g)?([0-9a-fA-F]+))?(?:-dirty)?$/i;
@@ -1344,11 +1344,11 @@ module.exports = React.createClass({
                     </div>
                     <div className="mx_UserSettings_advanced">
                         { _t('matrix-react-sdk version:') } { (REACT_SDK_VERSION !== '<local>')
-                            ? gHVersionLabel('matrix-org/matrix-react-sdk', REACT_SDK_VERSION)
+                            ? gHVersionLabel('dinsic-pim/matrix-react-sdk', REACT_SDK_VERSION)
                             : REACT_SDK_VERSION
                         }<br />
                         { _t('tchap-web version:') } { (this.state.vectorVersion !== undefined)
-                            ? this.state.vectorVersion
+                            ? gHVersionLabel('dinsic-pim/tchap-web', this.state.vectorVersion)
                             : 'unknown'
                         }<br />
                         { _t("olm version:") } { olmVersionString }<br />


### PR DESCRIPTION
The uses of appVersion and version inside the package.json have changed : 
- "version" refers to the react-sdk version
- "appVersion" refers to the application version (have to be the same as "version" inside the tchap-web package.json)

Now, versions appearing inside the user parameters follow this new uses.