### PR TITLE
Bug Fix - Encrypted attachments : Fix send attachments on encrypted rooms for Firefox 52.x

### DIFF
--- a/src/utils/ContentScanner.js
+++ b/src/utils/ContentScanner.js
@@ -1,6 +1,5 @@
 import MatrixClientPeg from "../MatrixClientPeg";
 import 'isomorphic-fetch';
-import {PkEncryption} from "olm";
 import Promise from "bluebird";
 import {decryptFile} from "./DecryptFile";
 
@@ -57,7 +56,7 @@ export async function scanContent(content) {
 		let body;
 		if (publicKey) {
 			// Setting up the encryption
-			const encryption = new PkEncryption();
+			const encryption = new global.Olm.PkEncryption();
 			encryption.set_recipient_key(publicKey);
 			body = {encrypted_body: encryption.encrypt(JSON.stringify({file: content.file}))};
 		} else {

--- a/src/utils/DecryptFile.js
+++ b/src/utils/DecryptFile.js
@@ -18,7 +18,6 @@ import 'isomorphic-fetch';
 // Grab the client so that we can turn mxc:// URLs into https:// URLS.
 import MatrixClientPeg from '../MatrixClientPeg';
 import Promise from 'bluebird';
-import {PkEncryption} from "olm";
 // WARNING: We have to be very careful about what mime-types we allow into blobs,
 // as for performance reasons these are now rendered via URL.createObjectURL()
 // rather than by converting into data: URIs.
@@ -97,7 +96,7 @@ export async function decryptFile(file) {
     let body;
     if (publicKey) {
         // Setting up the encryption
-        const encryption = new PkEncryption();
+        const encryption = new global.Olm.PkEncryption();
         encryption.set_recipient_key(publicKey);
         body = {encrypted_body: encryption.encrypt(JSON.stringify({file: file}))};
     } else {


### PR DESCRIPTION
Fix sending attachments on encrypted rooms on Firefox 52.x.

Resolve #215 