### PR TITLE
[Tchap-v2] Fix the method which returns the domain in public rooms list

### DIFF
--- a/src/Tchap.js
+++ b/src/Tchap.js
@@ -20,12 +20,12 @@ class Tchap {
     }
 
     /**
-     * Return a short value from a room alias.
-     * @param {string} alias The alias to shorten.
-     * @returns {string} The shortened alias.
+     * Return a domain name from a room_id.
+     * @param {string} id The room_id to analyse.
+     * @returns {string} The extracted domain name.
      */
-    static getDomainFromAlias(alias) {
-        const domain = alias.split(':').reverse()[0].split('.tchap.gouv.fr')[0].split('.').filter(Boolean).reverse()[0];
+    static getDomainFromId(id) {
+        const domain = id.split(':').reverse()[0].split('.tchap.gouv.fr')[0].split('.').filter(Boolean).reverse()[0];
 
         return this._capitalize(domain) || 'Tchap';
     }

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -358,7 +358,6 @@ module.exports = React.createClass({
         const rows = [];
         const self = this;
 
-        let guestRead; let guestJoin; let perms;
         rooms.sort((a, b) => {
             return b.num_joined_members - a.num_joined_members;
         });
@@ -370,7 +369,7 @@ module.exports = React.createClass({
                 name = `${name.substring(0, MAX_NAME_LENGTH)}...`;
             }
 
-            const domain = Tchap.getDomainFromAlias(get_display_alias_for_room(rooms[i]));
+            const domain = Tchap.getDomainFromId(rooms[i].room_id);
 
             let topic = rooms[i].topic || '';
             if (topic.length > MAX_TOPIC_LENGTH) {


### PR DESCRIPTION
The method returning the domain used the alias. Now, it will use the room_id.