### PR TITLE
[Tchap-v2] Re-enable redlist for extern users

### DIFF
--- a/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
+++ b/src/components/views/settings/tabs/user/GeneralUserSettingsTab.js
@@ -116,22 +116,17 @@ export default class GeneralUserSettingsTab extends React.Component {
 
     _renderAccountSection() {
         const ChangePassword = sdk.getComponent("views.settings.ChangePassword");
-        const isUserExtern = Tchap.isCurrentUserExtern();
-        let redListOption;
-
-        if (!isUserExtern) {
-            redListOption = (
-                <span>
-                    <LabelledToggleSwitch value={this.state.redList}
-                        onChange={this._onRedlistOptionChange}
-                        label={_t('Register my account on the red list')} />
-                    <p className="mx_SettingsTab_subsectionText">
-                    ({_t("Other users will not be able to discover my account on their searches")})
-                    </p>
-                    <br />
-                </span>
-            );
-        }
+        const redListOption = (
+            <span>
+                <LabelledToggleSwitch value={this.state.redList}
+                    onChange={this._onRedlistOptionChange}
+                    label={_t('Register my account on the red list')} />
+                <p className="mx_SettingsTab_subsectionText">
+                ({_t("Other users will not be able to discover my account on their searches")})
+                </p>
+                <br />
+            </span>
+        );
 
         const passwordChangeForm = (
             <ChangePassword


### PR DESCRIPTION
Re-enable redlist for extern users.

Refers to #238 and dinsic-pim/tchap-web#37.


See #201 for more informations.