### PR TITLE
Invitation : Fix email invitation

### DIFF
--- a/src/Tchap.js
+++ b/src/Tchap.js
@@ -104,7 +104,7 @@ class Tchap {
      * @returns {boolean}
      */
     static isUserExternFromServerHostname(hs) {
-        return hs.includes('e.') || hs.includes('externe.');
+        return hs.startsWith('e.') || hs.startsWith('agent.externe.');
     }
 
     /**


### PR DESCRIPTION
Due to an error on the "external" detection pattern, some users are not able to invite users by email.

Resolve dinsic-pim/tchap-web#94