### PR TITLE
Keys export : Fix the name of the keys file export

### DIFF
--- a/src/async-components/views/dialogs/ExportE2eKeysDialog.js
+++ b/src/async-components/views/dialogs/ExportE2eKeysDialog.js
@@ -79,7 +79,7 @@ export default React.createClass({
             const blob = new Blob([f], {
                 type: 'text/plain;charset=us-ascii',
             });
-            FileSaver.saveAs(blob, 'riot-keys.txt');
+            FileSaver.saveAs(blob, 'tchap-keys.txt');
             this.props.onFinished(true);
         }).catch((e) => {
             console.error("Error exporting e2e keys:", e);


### PR DESCRIPTION
Change the name of the key export file from "riot-keys.txt" to "tchap-keys.txt".

Resolve dinsic-pim/tchap-web#100