### PR TITLE
Room : Fix infinite loading wheel on room preview

### DIFF
--- a/src/components/structures/RoomView.js
+++ b/src/components/structures/RoomView.js
@@ -342,6 +342,7 @@ module.exports = React.createClass({
                     // Stop peeking if anything went wrong
                     this.setState({
                         isPeeking: false,
+                        peekLoading: false,
                     });
 
                     // This won't necessarily be a MatrixError, but we duck-type


### PR DESCRIPTION
Due to a change in the server response, trying to join a room (and landing on preview page) can lead to an infinite loading wheel.